### PR TITLE
Feature Addition: Terminal Config for hyperparams.json

### DIFF
--- a/repair_agent/manage_config.py
+++ b/repair_agent/manage_config.py
@@ -1,89 +1,161 @@
 import json
 import argparse
-import os
 from pathlib import Path
+import shutil
+import sys
 
-# Path to hyperparams.json in same directory
-HYPERPARAMS_PATH = Path(__file__).resolve().parent / "hyperparams.json"
+HERE = Path(__file__).resolve().parent
+HYPERPARAMS_PATH = HERE / "hyperparams.json"
+DEFAULT_HYPERPARAMS_PATH = HERE / "terminalconfig_default_hyperparams.json"
 
-# Default values required by your spec
-DEFAULTS = {
-    "budget_control_strategy": "FULL-TRACK",
+# Defaults sourced from terminalconfig_default_hyperparams.json
+DISPLAY_DEFAULTS = {
+    "budget_control": {"name": "FULL-TRACK"},
     "commands_limit": 40,
-    "external_fix_strategy": 0
+    "external_fix_strategy": 0,
+    "repetition_handling": "RESTRICT"
 }
 
-def load_hyperparams():
-    with open(HYPERPARAMS_PATH, "r") as f:
+VALID_BUDGET_OPTIONS = {"FULL-TRACK", "NO-TRACK", "FORCED"}
+VALID_REPETITION_OPTIONS = {"ALLOW", "RESTRICT"}
+
+def load_json(path: Path):
+    if not path.exists():
+        raise FileNotFoundError(f"{path} not found.")
+    with path.open("r", encoding="utf-8") as f:
         return json.load(f)
 
-def save_hyperparams(data):
-    with open(HYPERPARAMS_PATH, "w") as f:
+def save_json(path: Path, data):
+    with path.open("w", encoding="utf-8") as f:
         json.dump(data, f, indent=4)
 
 def display_current_and_defaults():
-    current = load_hyperparams()
-    print("\n=== RepairAgent Quick Configuration ===")
-    print(f"Budget Control Strategy:   current={current.get('budget_control.name')}  default={DEFAULTS['budget_control_strategy']}")
-    print(f"Commands Limit:            current={current.get('commands_limit')}          default={DEFAULTS['commands_limit']}")
-    print(f"External Fix Strategy:     current={current.get('external_fix_strategy')}    default={DEFAULTS['external_fix_strategy']}")
-    print("=================================\n")
+    try:
+        current = load_json(HYPERPARAMS_PATH)
+    except FileNotFoundError:
+        print(f"Could not find {HYPERPARAMS_PATH}.")
+        return
+
+    budget_name = current.get("budget_control", {}).get("name")
+    commands_limit = current.get("commands_limit")
+    external_fix = current.get("external_fix_strategy")
+    repetition = current.get("repetition_handling", DISPLAY_DEFAULTS["repetition_handling"])
+
+    print("\n=== RepairAgent hyperparams (current vs display-default) ===")
+    print(f"Budget Control (budget_control.name):   current={budget_name}   default={DISPLAY_DEFAULTS['budget_control']['name']}")
+    print(f"Commands Limit (commands_limit):        current={commands_limit}    default={DISPLAY_DEFAULTS['commands_limit']}")
+    print(f"External Fix Strategy (external_fix_strategy): current={external_fix}    default={DISPLAY_DEFAULTS['external_fix_strategy']}")
+    print(f"Repetition Handling (repetition_handling): current={repetition}    default={DISPLAY_DEFAULTS['repetition_handling']}")
+    print("============================================================\n")
 
 def apply_changes(args):
-    data = load_hyperparams()
+    # Load the existing hyperparams (so we preserve keys we aren't changing)
+    data = load_json(HYPERPARAMS_PATH)
 
-    if args.strategy:
-        if args.strategy not in ["FULL-TRACK", "NO-TRACK"]:
-            raise ValueError("budget_control must be FULL-TRACK or NO-TRACK")
-        data["budget_control_strategy"] = args.strategy
+    # Budget control (stored as nested object)
+    if args.strategy is not None:
+        strat = args.strategy.upper()
+        if strat not in VALID_BUDGET_OPTIONS:
+            raise ValueError(f"budget_control must be one of {sorted(VALID_BUDGET_OPTIONS)}")
+        # Ensure budget_control object exists
+        if "budget_control" not in data or not isinstance(data["budget_control"], dict):
+            data["budget_control"] = {}
+        data["budget_control"]["name"] = strat
 
+    # repetition_handling
+    if args.repetition is not None:
+        rep = args.repetition.upper()
+        if rep not in VALID_REPETITION_OPTIONS:
+            raise ValueError(f"repetition_handling must be one of {sorted(VALID_REPETITION_OPTIONS)}")
+        data["repetition_handling"] = rep
+
+    # commands_limit
     if args.commands is not None:
+        # note: check for None explicitly so 0 would work if it were allowed (but here min is 1)
         if not (1 <= args.commands <= 100):
             raise ValueError("commands_limit must be between 1 and 100")
         data["commands_limit"] = args.commands
 
+    # external_fix_strategy: min 0, max 3
     if args.external is not None:
         if not (0 <= args.external <= 3):
-            raise ValueError("external_fix_strategy must be between 0 and 3")
+            raise ValueError("external_fix_strategy must be between 0 and 3 (inclusive)")
         data["external_fix_strategy"] = args.external
 
-    save_hyperparams(data)
+    save_json(HYPERPARAMS_PATH, data)
+
+def reset_to_defaults():
+    if not DEFAULT_HYPERPARAMS_PATH.exists():
+        raise FileNotFoundError(f"terminalconfig_default_hyperparams.json not found at {DEFAULT_HYPERPARAMS_PATH}")
+    # Overwrite hyperparams.json with terminalconfig_default_hyperparams.json
+    shutil.copyfile(DEFAULT_HYPERPARAMS_PATH, HYPERPARAMS_PATH)
+    print(f"Reset complete: {HYPERPARAMS_PATH} overwritten with {DEFAULT_HYPERPARAMS_PATH}")
 
 def print_welcome_banner():
-    """Call this at startup of RepairAgent."""
-
+    """Call this at RepairAgent startup to notify about the config tool."""
     print("\n=== Welcome to RepairAgent ===")
-    print("A configuration tool is available to adjust run settings.")
-    print("Run it with:")
+    print("To change runtime hyperparameters run the config tool:")
     print("    python -m repair_agent.config.manage_config --help")
-    print("\nDefault Settings:")
-    print(f"  Budget Control Strategy:  {DEFAULTS['budget_control_strategy']}")
-    print(f"  Commands Limit:           {DEFAULTS['commands_limit']}")
-    print(f"  External Fix Strategy:    {DEFAULTS['external_fix_strategy']}")
-    print("=================================\n")
+    print("\nDefault / display values (these are the program defaults shown at startup):")
+    print(f"  Budget Control:          {DISPLAY_DEFAULTS['budget_control']['name']} (options: FULL-TRACK, NO-TRACK, FORCED)")
+    print(f"  Repetition Handling:     {DISPLAY_DEFAULTS['repetition_handling']} (options: ALLOW, RESTRICT)")
+    print(f"  Commands Limit:          {DISPLAY_DEFAULTS['commands_limit']} (range: 1-100)")
+    print(f"  External Fix Strategy:   {DISPLAY_DEFAULTS['external_fix_strategy']} (range: 0-5)")
+    print("===============================================\n")
 
-def main():
+def parse_args(argv):
     parser = argparse.ArgumentParser(description="Modify RepairAgent hyperparameters")
 
-    parser.add_argument("--strategy", help="FULL-TRACK or NO-TRACK")
-    parser.add_argument("--commands", type=int, help="Command limit (1-100)")
-    parser.add_argument("--external", type=int, help="External fix strategy (0-3)")
-    parser.add_argument("--show", action="store_true", help="Show current & default values")
+    parser.add_argument("--strategy", type=str,
+                        help="Budget control strategy: FULL-TRACK, NO-TRACK, or FORCED")
 
-    args = parser.parse_args()
+    parser.add_argument("--repetition", type=str,
+                        help="Repetition handling: ALLOW or RESTRICT")
+
+    parser.add_argument("--commands", type=int,
+                        help="commands_limit (integer 1-100)")
+
+    # EXTERNAL must accept 0 — check for is not None in code
+    parser.add_argument("--external", type=int,
+                        help="external_fix_strategy (integer 0-5)")
+
+    parser.add_argument("--show", action="store_true",
+                        help="Show current and default values")
+
+    parser.add_argument("--reset", action="store_true",
+                        help="Reset hyperparams.json to default_hyperparams.json (overwrite)")
+
+    return parser.parse_args(argv)
+
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv[1:]
+    args = parse_args(argv)
 
     if args.show:
         display_current_and_defaults()
         return
 
-    if not any([args.strategy, args.commands, args.external]):
-        print("No changes specified. Use --help for options.")
+    if args.reset:
+        reset_to_defaults()
+        # show the current values after reset
+        display_current_and_defaults()
         return
 
-    apply_changes(args)
+    # If no modifications requested, tell user how to use --show/--help
+    if not any([args.strategy, args.repetition, args.commands is not None, args.external is not None]):
+        print("No changes specified. Use --show to see current values or --help for usage.")
+        return
+
+    # Apply changes (validates and saves)
+    try:
+        apply_changes(args)
+    except Exception as exc:
+        print(f"Error applying changes: {exc}")
+        return
+
     print("Configuration updated!\n")
     display_current_and_defaults()
-
 
 if __name__ == "__main__":
     main()

--- a/repair_agent/manage_config.py
+++ b/repair_agent/manage_config.py
@@ -1,0 +1,89 @@
+import json
+import argparse
+import os
+from pathlib import Path
+
+# Path to hyperparams.json in same directory
+HYPERPARAMS_PATH = Path(__file__).resolve().parent / "hyperparams.json"
+
+# Default values required by your spec
+DEFAULTS = {
+    "budget_control_strategy": "FULL-TRACK",
+    "commands_limit": 40,
+    "external_fix_strategy": 0
+}
+
+def load_hyperparams():
+    with open(HYPERPARAMS_PATH, "r") as f:
+        return json.load(f)
+
+def save_hyperparams(data):
+    with open(HYPERPARAMS_PATH, "w") as f:
+        json.dump(data, f, indent=4)
+
+def display_current_and_defaults():
+    current = load_hyperparams()
+    print("\n=== RepairAgent Quick Configuration ===")
+    print(f"Budget Control Strategy:   current={current.get('budget_control.name')}  default={DEFAULTS['budget_control_strategy']}")
+    print(f"Commands Limit:            current={current.get('commands_limit')}          default={DEFAULTS['commands_limit']}")
+    print(f"External Fix Strategy:     current={current.get('external_fix_strategy')}    default={DEFAULTS['external_fix_strategy']}")
+    print("=================================\n")
+
+def apply_changes(args):
+    data = load_hyperparams()
+
+    if args.strategy:
+        if args.strategy not in ["FULL-TRACK", "NO-TRACK"]:
+            raise ValueError("budget_control must be FULL-TRACK or NO-TRACK")
+        data["budget_control_strategy"] = args.strategy
+
+    if args.commands is not None:
+        if not (1 <= args.commands <= 100):
+            raise ValueError("commands_limit must be between 1 and 100")
+        data["commands_limit"] = args.commands
+
+    if args.external is not None:
+        if not (0 <= args.external <= 3):
+            raise ValueError("external_fix_strategy must be between 0 and 3")
+        data["external_fix_strategy"] = args.external
+
+    save_hyperparams(data)
+
+def print_welcome_banner():
+    """Call this at startup of RepairAgent."""
+
+    print("\n=== Welcome to RepairAgent ===")
+    print("A configuration tool is available to adjust run settings.")
+    print("Run it with:")
+    print("    python -m repair_agent.config.manage_config --help")
+    print("\nDefault Settings:")
+    print(f"  Budget Control Strategy:  {DEFAULTS['budget_control_strategy']}")
+    print(f"  Commands Limit:           {DEFAULTS['commands_limit']}")
+    print(f"  External Fix Strategy:    {DEFAULTS['external_fix_strategy']}")
+    print("=================================\n")
+
+def main():
+    parser = argparse.ArgumentParser(description="Modify RepairAgent hyperparameters")
+
+    parser.add_argument("--strategy", help="FULL-TRACK or NO-TRACK")
+    parser.add_argument("--commands", type=int, help="Command limit (1-100)")
+    parser.add_argument("--external", type=int, help="External fix strategy (0-3)")
+    parser.add_argument("--show", action="store_true", help="Show current & default values")
+
+    args = parser.parse_args()
+
+    if args.show:
+        display_current_and_defaults()
+        return
+
+    if not any([args.strategy, args.commands, args.external]):
+        print("No changes specified. Use --help for options.")
+        return
+
+    apply_changes(args)
+    print("Configuration updated!\n")
+    display_current_and_defaults()
+
+
+if __name__ == "__main__":
+    main()

--- a/repair_agent/manage_config.py
+++ b/repair_agent/manage_config.py
@@ -100,7 +100,7 @@ def print_welcome_banner():
     print(f"  Budget Control:          {DISPLAY_DEFAULTS['budget_control']['name']} (options: FULL-TRACK, NO-TRACK, FORCED)")
     print(f"  Repetition Handling:     {DISPLAY_DEFAULTS['repetition_handling']} (options: ALLOW, RESTRICT)")
     print(f"  Commands Limit:          {DISPLAY_DEFAULTS['commands_limit']} (range: 1-100)")
-    print(f"  External Fix Strategy:   {DISPLAY_DEFAULTS['external_fix_strategy']} (range: 0-5)")
+    print(f"  External Fix Strategy:   {DISPLAY_DEFAULTS['external_fix_strategy']} (range: 0-3)")
     print("===============================================\n")
 
 def parse_args(argv):
@@ -117,7 +117,7 @@ def parse_args(argv):
 
     # EXTERNAL must accept 0 — check for is not None in code
     parser.add_argument("--external", type=int,
-                        help="external_fix_strategy (integer 0-5)")
+                        help="external_fix_strategy (integer 0-3)")
 
     parser.add_argument("--show", action="store_true",
                         help="Show current and default values")

--- a/repair_agent/terminalconfig_default_hyperparams.json
+++ b/repair_agent/terminalconfig_default_hyperparams.json
@@ -1,0 +1,11 @@
+{
+    "budget_control": {
+        "name": "FULL-TRACK",
+        "params": {
+            "#fixes": 4
+        }
+    },
+    "repetition_handling": "RESTRICT",
+    "external_fix_strategy": 0,
+    "commands_limit": 40
+}


### PR DESCRIPTION
# Purpose
The goal of this PR is to add a file, `manage_config.py`, that allows the user to change aspects of the hyperparameters for RepairAgent without needing to manually edit the file and risk making wrong inputs. This is a lightweight approach to the problem that would be suitable for developers that are more familiar with working from the command line.

# Files Added
* `manage_config.py` - Python file located in the repair_agent subfolder (same location as `hyperparams.json`) that produces a terminal UI for the user to make changes to the hyperparams.
* `terminalconfig_default_hyperparams.json` - This file is a template for the default hyperparams that is used by the show-default and reset commands in the above file.

# Screenshot
<img width="852" height="370" alt="image" src="https://github.com/user-attachments/assets/7e48c44c-ba40-4e1b-9be0-2cc958721007" />

# Additional Notes
The welcome banner functionality wasn't initially tested, but should not affect much if it remains unused. Reviewers that can test this functionality by calling RepairAgent's main function would be greatly appreciated for input.